### PR TITLE
Change npm package name to @bbge/blocks

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -23,4 +23,4 @@ common.pyc
 /gh-pages
 
 # Exclude already built packages from testing with npm pack
-/bb-blocks-*.{tar,tgz}
+/@bbge/blocks-*.{tar,tgz}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "bb-blocks",
+  "name": "@bbge/blocks",
   "version": "0.1.0",
-  "description": "bb-blocks is a library for building creative computing interfaces.",
+  "description": "@bbge/blocks is a library for building creative computing interfaces.",
   "author": "Massachusetts Institute of Technology",
   "license": "Apache-2.0",
   "homepage": "https://github.com/FBDY/bb-blocks",


### PR DESCRIPTION
npmjs registry don't allow us to use "bb-vm" as a package name. So, we decided to use scoped package names for all modules.