### PR TITLE
Fix git repository URL in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "homepage": "https://github.com/FBDY/bb-blocks",
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com:FBDY/bb-blocks.git"
+    "url": "https://github.com/FBDY/bb-blocks.git"
   },
   "main": "./dist/vertical.js",
   "browser": "./shim/vertical.js",


### PR DESCRIPTION
Git repository URL should be https, not ssh. As in the docs below:

https://docs.npmjs.com/files/package.json